### PR TITLE
SNS投稿時の画像パス修正

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -10,7 +10,7 @@ module.exports = {
 		author: 'Nobuhiro Harada',
 		description: 'nobuhiroharada.com',
 		siteUrl: 'https://nobuhiroharada.com',
-		image: `${__dirname}/static/sns-share.png`,
+		image: '/sns-share.png',
 		twitterUsername: "@nobuhiro_harada"
 	},
 	pathPrefix: '/nobuhiroharada_com',

--- a/src/components/head.js
+++ b/src/components/head.js
@@ -27,8 +27,8 @@ const Head = ({ title, description }) => {
 
 	let descriptionMeta = description || defaults.description
 	let urlMeta = defaults.siteUrl
-	let imageMeta = defaults.image
-	
+	let imageMeta = `${defaults.siteUrl}${defaults.image}`
+
 	return (
 		<Helmet>
 			<title>{titleMeta}</title>


### PR DESCRIPTION
staticフォルダに入れた画像はpublic直下に配置されるみたい

_You can create a folder named static at the root of your project. Every file you put into that folder will be copied into the public folder. E.g. if you add a file named sun.jpg to the static folder, it’ll be copied to public/sun.jpg_

https://www.gatsbyjs.org/docs/static-folder/